### PR TITLE
[BUGFIX] encoding backslash issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.0.9
+
+* Use p1_utils 1.0.7 (Christophe Romain)
+
 # Version 1.0.8
 
 * Load local .so instead from system package when running tests (Paweł Chmielowski)

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 {port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS -lyaml"}]}.
 {port_specs, [{"priv/lib/fast_yaml.so", ["c_src/fast_yaml.c"]}]}.
 
-{deps, [{p1_utils, ".*", {git, "git://github.com/processone/p1_utils", {tag, "1.0.6"}}}]}.
+{deps, [{p1_utils, ".*", {git, "git://github.com/processone/p1_utils", {tag, "1.0.7"}}}]}.
 
 {clean_files, ["c_src/fast_yaml.gcda", "c_src/fast_yaml.gcno"]}.
 

--- a/src/fast_yaml.app.src
+++ b/src/fast_yaml.app.src
@@ -23,7 +23,7 @@
 
 {application, fast_yaml,
  [{description,  "Fast YAML native library for Erlang / Elixir"},
-  {vsn,          "1.0.8"},
+  {vsn,          "1.0.9"},
   {modules,      []},
   {registered,   []},
   {applications, [kernel, stdlib]},


### PR DESCRIPTION
Fix bug when encoding a binary with any escape sequence: http://erlang.org/doc/reference_manual/data_types.html#escape-sequences

This PR fix them all with the exception of the escape sequence \d (delete)